### PR TITLE
Temporary fix for Illinois scraper.

### DIFF
--- a/src/events/crawler/scrapers/USA/IL/index.js
+++ b/src/events/crawler/scrapers/USA/IL/index.js
@@ -22,6 +22,8 @@ const scraper = {
     } else if (datetime.dateIsBefore(date, '2020-03-24')) {
       const datePart = datetime.getYYYYMMDD(date, '');
       this.url = `${this._baseUrl}COVID19CountyResults${datePart}.json`;
+    } else if (datetime.dateIsBefore(date, '2020-03-25')) {
+      this.url = `${this._baseUrl}COVID19CountyResults202003250.json`;
     } else {
       this.url = 'http://www.dph.illinois.gov/sitefiles/COVIDTestResults.json';
     }


### PR DESCRIPTION
Illinois is not using a consistent format for their filenames, so they have needed to be updated manually for each of the past 3-4 days. This fixes the URL for today's scrape (3/25). See related issue https://github.com/lazd/coronadatascraper/issues/290